### PR TITLE
Fix ssl compatibility issue when npm start locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run clean && tsc --build src/lib/tsconfig.json",
     "build_app": "npm run clean && tsc --build src/test_app/tsconfig.json",
-    "start": "npx webpack serve --config test_app.config.js",
+    "start": "export NODE_OPTIONS=--openssl-legacy-provider && npx webpack serve --config test_app.config.js",
     "pack": "npm run clean && npx webpack",
     "pack_app": "npm run clean && npx webpack --config test_app.config.js",
     "clean": "rimraf ./build ./dist",


### PR DESCRIPTION
When using Node.js v18.13.0 and npm run, it will report 
```
 whalechang   fix-ssl {1} U:3 ?:1  ~/workspace/libhidtelephony  npm start

> libhidtelephony@0.0.1 start
> npx webpack serve --config test_app.config.js

<i> [webpack-dev-server] Project is running at:
<i> [webpack-dev-server] Loopback: http://localhost:8080/
<i> [webpack-dev-server] On Your Network (IPv4): http://100.103.76.91:8080/
<i> [webpack-dev-server] On Your Network (IPv6): http://[fe80::3243:b6fe:127e:a831]:8080/
<i> [webpack-dev-server] Content not from webpack is served from '/usr/local/google/home/whalechang/workspace/libhidtelephony/public' directory
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/util/createHash.js:144:18)
    at BulkUpdateDecorator.update (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/util/createHash.js:46:50)
    at RawSource.updateHash (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack-sources/lib/RawSource.js:64:8)
    at NormalModule._initBuildHash (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:839:17)
    at handleParseResult (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:904:10)
    at /usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:995:4
    at processResult (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:718:11)
    at /usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:778:5
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/util/createHash.js:144:18)
    at BulkUpdateDecorator.update (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/util/createHash.js:46:50)
    at RawSource.updateHash (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack-sources/lib/RawSource.js:64:8)
    at NormalModule._initBuildHash (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:839:17)
    at handleParseResult (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:904:10)
    at /usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:995:4
    at processResult (/usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:718:11)
    at /usr/local/google/home/whalechang/workspace/libhidtelephony/node_modules/webpack/lib/NormalModule.js:778:5 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

So I force using openssl-legacy-provider to fix this issue.